### PR TITLE
Added basic host setup docs

### DIFF
--- a/apps/docs/docs/hosts.md
+++ b/apps/docs/docs/hosts.md
@@ -24,6 +24,7 @@ Open the `config.yaml` file at the root of the project, here we will place some 
     - `keyring_secret` - can sometimes be useful for tests. Instead, it is generally recommended to set an environment variable `DEFRA_KEYRING_SECRET` to a keyring secret. This secret can be any secure passcode - it is recommended to use a secure password generator to create one. The `DEFRA_KEYRING_SECRET` will overwrite any `keyring_secret` provided in config.yaml - you are welcome to remove this field from config altogether.
     - `p2p` *Very important - if not done correctly your Host will not receive primitive data from Indexers*
         - `bootstrap_peers` - these nodes will be your initial connection point to the network. By default, we will provide at least one bootstrap peer for you to connect with so that you can join the Shinzo network. However, if you can grab some peer info for reliable Indexers from the Shinzo block explorer and include them here, it can really boost the speed with which your Host gets connected to Shinzo and starts hosting Views.
+            - `peers` You will need the peer's IP_ADDRESS and PEER_ID to complete the connection string: ['/ipv4/<IP_ADDRESS>/tcp/9171/p2p/<PEER_ID>']
         - `listen_addr` - the default value of "/ip4/0.0.0.0/tcp/0" should be sufficient when running locally. If running in a container, you'll want to manually choose a port "/ip4/0.0.0.0/tcp/\<your port here\>" so that you can expose that port in your container.
 
 - `store`


### PR DESCRIPTION
# Pull Request

## Description
Adds docs for setting up the host

## Changes
Added doc

## Related Issue
https://github.com/shinzonetwork/web/issues/17

## Steps to Test
Follow the steps outlined in the doc to validate that they work. Please also review for understandability, grammar, etc.

## Checklist
- [ ] Code compiles / runs
- [ ] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [ ] Code does not break any existing features
- [ ] Code passes personal internal testing

Rest of checklist is irrelevant to this PR

## Notes
These docs assume that we have a required peer to bootstrap Hosts into the network - this is not currently true - once we have a stable indexer (or even any defra node connected to the rest of shinzo that we plan to keep running), we can add it as a required peer [here](https://github.com/shinzonetwork/shinzo-host-client/blob/main/pkg/host/host.go#L34). It is also recommended that we include the production shinzohub websocket url in the default config.yaml.
