### PR TITLE
Removing the address links

### DIFF
--- a/apps/explorer/lib/pages/block-details/block-card.tsx
+++ b/apps/explorer/lib/pages/block-details/block-card.tsx
@@ -26,7 +26,6 @@ export const BlockCard = ({ height }: BlockCardProps) => {
         <DataItem
           title="Block Height"
           value={block.number}
-          copyable
           loading={isLoading}
         >
           {block.number}
@@ -35,7 +34,6 @@ export const BlockCard = ({ height }: BlockCardProps) => {
         <DataItem
           title="Timestamp"
           value={block.number}
-          copyable
           loading={isLoading}
         >
           {block.timestamp &&
@@ -45,8 +43,6 @@ export const BlockCard = ({ height }: BlockCardProps) => {
         <DataItem
           title="Miner"
           value={block.miner}
-          link={block.miner ? `/address/${block.miner}` : undefined}
-          copyable
           loading={isLoading}
         >
           {block.miner}

--- a/apps/explorer/lib/pages/blocks/page.tsx
+++ b/apps/explorer/lib/pages/blocks/page.tsx
@@ -18,6 +18,7 @@ import {
   TableNullableCell,
 } from '@/shared/ui/table';
 import { useBlocks } from './use-blocks';
+import { CopyButton } from "@/shared/ui/button";
 
 export interface BlocksPageClientProps {
   pageParams: PageParams;
@@ -82,12 +83,10 @@ export const BlocksPageClient = ({ pageParams }: BlocksPageClientProps) => {
 
             <TableNullableCell value={block?.miner} nowrap>
               {(value) => (
-                <Link
-                  href={`/address/${value}`}
-                  className="font-mono text-sm hover:underline"
-                >
-                  {formatHash(value, 8, 6)}
-                </Link>
+                <div className="flex items-center gap-1 text-sm text-foreground">
+                  {formatHash(value ?? '', 8, 6)}
+                  <CopyButton text={value ?? ''} className="text-muted-foreground" />
+                </div>
               )}
             </TableNullableCell>
 

--- a/apps/explorer/lib/pages/home/blocks-home.tsx
+++ b/apps/explorer/lib/pages/home/blocks-home.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/shared/utils/utils';
 import { useShortBlocks } from './use-short-blocks';
 import { useHighlight } from './use-highlight';
 import { useMemo } from 'react';
+import { CopyButton } from "@/shared/ui/button";
 
 /** A container that takes at most 50% of the width, so that a spacer can take up all the rest width */
 export const HALF_CONTAINER_CLASS = cn('w-full max-w-full lg:max-w-lg xl:max-w-160 2xl:max-w-3xl')
@@ -88,19 +89,9 @@ export const BlocksHome = () => {
 
               <TableNullableCell value={block?.miner} align="center" className={highlightClass}>
                 {(value) => (
-                  <div className="flex flex-row gap-1">
-                    <Typography>Miner:</Typography>
-                    <Link
-                      href={`/address/${value}`}
-                      className="font-mono text-sm hover:underline pt-[2]"
-                    >
-                      <Typography
-                        color="accent"
-                        className="font-mono text-sm hover:underline"
-                      >
-                        {formatHash(value, 8, 6)}
-                      </Typography>
-                    </Link>
+                  <div className="flex items-center gap-1 text-sm text-foreground">
+                    {formatHash(value ?? '', 8, 6)}
+                    <CopyButton text={value ?? ''} className="text-muted-foreground" />
                   </div>
                 )}
               </TableNullableCell>

--- a/apps/explorer/lib/pages/home/transactions-home.tsx
+++ b/apps/explorer/lib/pages/home/transactions-home.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/shared/utils/utils';
 import { HALF_CONTAINER_CLASS } from './blocks-home';
 import { useShortTransactions } from './use-short-transactions';
 import { useHighlight } from './use-highlight';
+import { CopyButton } from '@/shared/ui/button';
 
 export const TransactionsHome = () => {
   const { data: transactions, isLoading } = useShortTransactions();
@@ -67,34 +68,20 @@ export const TransactionsHome = () => {
                   <div className="flex flex-col gap-1">
                     {value && (
                       <div className="flex flex-row gap-2">
-                        <Typography>From</Typography>
-                        <Link
-                          href={`/address/${value}`}
-                          className="font-mono text-sm hover:underline pt-[2]"
-                        >
-                          <Typography
-                            color="accent"
-                            className="font-mono text-sm hover:underline"
-                          >
-                            {formatHash(value, 8, 6)}
-                          </Typography>
-                        </Link>
-                      </div>
+                        <Typography>From: </Typography>
+                        <div className="flex items-center gap-1 text-sm text-foreground">
+                          {formatHash(value ?? '', 8, 6)}
+                          <CopyButton text={value ?? ''} className="text-muted-foreground" />
+                        </div>
+                     </div>
                     )}
                     {tx?.to && (
                       <div className="flex flex-row gap-2">
-                        <Typography>To</Typography>
-                        <Link
-                          href={`/address/${tx?.to}`}
-                          className="font-mono text-sm hover:underline pt-[2]"
-                        >
-                          <Typography
-                            color="accent"
-                            className="font-mono text-sm hover:underline"
-                          >
-                            {formatHash(tx?.to, 8, 6)}
-                          </Typography>
-                        </Link>
+                        <Typography>To: </Typography>
+                        <div className="flex items-center gap-1 text-sm text-foreground">
+                          {formatHash(value ?? '', 8, 6)}
+                          <CopyButton text={value ?? ''} className="text-muted-foreground" />
+                        </div>
                       </div>
                     )}
                   </div>

--- a/apps/explorer/lib/pages/transaction-details/transaction-card.tsx
+++ b/apps/explorer/lib/pages/transaction-details/transaction-card.tsx
@@ -108,8 +108,6 @@ export const TransactionCard = ({ txHash }: TransactionCardProps) => {
       <DataItem
         title='From'
         value={tx.from}
-        link={`/address/${tx.from}`}
-        copyable
         loading={isLoading}
       >
         {tx.from}
@@ -118,8 +116,6 @@ export const TransactionCard = ({ txHash }: TransactionCardProps) => {
       <DataItem
         title="To"
         value={tx.to}
-        link={`/address/${tx.to}`}
-        copyable
         loading={isLoading}
       >
         {tx.to}
@@ -183,7 +179,6 @@ export const TransactionCard = ({ txHash }: TransactionCardProps) => {
         title="Input Data"
         value={tx.input}
         loading={isLoading}
-        copyable
         allowWrap
         wrapAt={tx.input && tx.input.length > 100 ? 100 : tx.input?.length}
       >

--- a/apps/explorer/lib/pages/transactions/transactions-list.tsx
+++ b/apps/explorer/lib/pages/transactions/transactions-list.tsx
@@ -8,6 +8,7 @@ import {
   TableNullableCell,
 } from '@/shared/ui/table';
 import { Transaction } from '@/shared/graphql';
+import { CopyButton } from '@/shared/ui/button';
 
 export const TransactionsList = ({ transactions, isLoading }: { transactions: Transaction[] | undefined, isLoading: boolean }) => {
   const formatValue = (value: string) => {
@@ -58,17 +59,19 @@ export const TransactionsList = ({ transactions, isLoading }: { transactions: Tr
 
             <TableNullableCell value={tx?.from}>
               {(value) => (
-                <Link href={`/address/${value}`} className="font-mono text-sm hover:underline">
-                  {formatHash(value, 8, 6)}
-                </Link>
+                <div className="flex items-center gap-1 text-sm text-foreground">
+                 {formatHash(value ?? '', 8, 6)}
+                 <CopyButton text={value ?? ''} className="text-muted-foreground" />
+               </div>
               )}
             </TableNullableCell>
 
             <TableNullableCell value={tx?.to}>
               {(value) => (
-                <Link href={`/address/${value}`} className="font-mono text-sm hover:underline">
-                  {formatHash(value, 8, 6)}
-                </Link>
+                <div className="flex items-center gap-1 text-sm text-foreground">
+                  {formatHash(value ?? '', 8, 6)}
+                  <CopyButton text={value ?? ''} className="text-muted-foreground" />
+               </div>
               )}
             </TableNullableCell>
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does and why -->
The address route is not yet implemented in the explorer and the current links to the navigate to the addresses is breaking the UI. This PR remove all the address links for explorer and we can add them back once we have the route set up at a later point.

## Changes

- Remove the `Link` for addresses with `div` and `Typography` and added the <CopyButton /> to make them copiable.

## Related Issue
<!-- Link to the issue this PR addresses, if any -->
#73 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Make sure none of the addresses displayed such as miner address, to address and from address are still links.

## Checklist
- [ ] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [ ] PR is self-contained and focused
- [ ] Code does not break any existing features
- [ ] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
