### PR TITLE
Adding proxy to handle the CORS error at the client side.

### DIFF
--- a/apps/explorer/app/api/graphql/route.ts
+++ b/apps/explorer/app/api/graphql/route.ts
@@ -1,0 +1,71 @@
+import { getGraphQLUrl } from "@/shared/utils/consts";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GraphQL API proxy route
+ * Proxies requests to the actual GraphQL endpoint to avoid CORS issues
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const graphqlUrl = getGraphQLUrl();
+
+    // Get the request body from the incoming request
+    const body = await request.json();
+
+    // Forward the request to the actual GraphQL endpoint
+    const response = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(request.headers.get("authorization") && {
+          authorization: request.headers.get("authorization")!,
+        }),
+      },
+      body: JSON.stringify(body),
+    });
+
+    // Get the response data
+    const data = await response.json();
+
+    // Return the response with proper CORS headers
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      },
+    });
+  } catch (error) {
+    console.error("GraphQL proxy error:", error);
+    return NextResponse.json(
+      {
+        errors: [
+          {
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to proxy GraphQL request",
+          },
+        ],
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Handle OPTIONS requests for CORS preflight
+ */
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    },
+  });
+}
+

--- a/apps/explorer/lib/shared/graphql/codegen.ts
+++ b/apps/explorer/lib/shared/graphql/codegen.ts
@@ -1,9 +1,10 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 import { customFetch } from './custom-fetch';
+import { getGraphQLUrl } from '../utils/consts';
 
 // copy of the `utils/consts.ts` but using loadEnvFile beforehand to apply .env file
 process.loadEnvFile('.env');
-const GRAPHQL_URL = process.env.NEXT_PUBLIC_GRAPHQL_URL ?? 'http://localhost:9181/api/v0/graphql';
+const GRAPHQL_URL = getGraphQLUrl();
 
 const config: CodegenConfig = {
   schema: [

--- a/apps/explorer/lib/shared/graphql/execute.ts
+++ b/apps/explorer/lib/shared/graphql/execute.ts
@@ -1,15 +1,18 @@
-import { GRAPHQL_URL } from '../utils/consts';
+import { getGraphQLUrl } from '../utils/consts';
 import type { TypedDocumentString } from './generated/graphql'
 
 export async function execute<TResult, TVariables>(
   query: TypedDocumentString<TResult, TVariables>,
   ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
 ) {
-  const response = await fetch(GRAPHQL_URL, {
+  // Use getGraphQLUrl() which returns the proxy endpoint on client-side
+  const url = getGraphQLUrl();
+  
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Accept: 'application/graphql-response+json'
+      Accept: 'application/json'
     },
     body: JSON.stringify({
       query,
@@ -18,9 +21,20 @@ export async function execute<TResult, TVariables>(
   })
 
   if (!response.ok) {
-    throw new Error('Network response was not ok')
+    throw new Error(`GraphQL request failed with status ${response.status}: ${response.statusText}`)
   }
 
-  const data = await response.json() as { data: TResult };
+  const data = await response.json() as { data?: TResult; errors?: Array<{ message: string }> };
+  
+  // Check for GraphQL errors in the response
+  if (data.errors && data.errors.length > 0) {
+    const errorMessages = data.errors.map((e) => e.message).join(', ');
+    throw new Error(`GraphQL errors: ${errorMessages}`);
+  }
+
+  if (!data.data) {
+    throw new Error('GraphQL response contains no data');
+  }
+
   return data.data;
 }

--- a/apps/explorer/lib/shared/utils/consts.ts
+++ b/apps/explorer/lib/shared/utils/consts.ts
@@ -1,1 +1,17 @@
-export const GRAPHQL_URL = process.env.NEXT_PUBLIC_GRAPHQL_URL ?? 'http://localhost:9181/api/v0/graphql';
+/**
+ * Get the GraphQL endpoint URL
+ * Returns the proxy endpoint if in client-side, or the actual GraphQL URL if in server-side
+ * The proxy endpoint is used to avoid CORS issues in the browser
+ */
+export function getGraphQLUrl(): string {
+  const graphqlUrl = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+
+  // In client-side, use the proxy endpoint to avoid CORS
+  if (typeof window !== "undefined") {
+    return "/api/graphql";
+  }
+
+  // In server-side, use the actual GraphQL endpoint
+  return graphqlUrl || "http://192.168.2.72:9181/api/v0/graphql";
+}
+


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does and why -->
This PR adds a proxy from at the client side to handle the CORS errors in the browser.

## Changes
-  Created GraphQL Proxy API Route (/app/api/graphql/route.ts)
- Added getGraphQLUrl() that returns /api/graphql on the client (proxy) and the actual URL on the server
- Switched to getGraphQLUrl() instead of the constant in execute.ts and codegen.ts

## Related Issue
<!-- Link to the issue this PR addresses, if any -->
#77 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Make sure the errors are no longer getting thrown in the console.

## Checklist
- [x] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
