### PR TITLE
Connecting metrics-dashboard to the host

### DIFF
--- a/apps/metrics-dashboard/.env.example
+++ b/apps/metrics-dashboard/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_METRICS_URL=http://localhost:8080/metrics

--- a/apps/metrics-dashboard/.gitignore
+++ b/apps/metrics-dashboard/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/metrics-dashboard/src/lib/context/hook/use-metrics.ts
+++ b/apps/metrics-dashboard/src/lib/context/hook/use-metrics.ts
@@ -5,7 +5,10 @@ import { METRICS_API_URL } from "@/lib/shared/utils/consts";
 import { MetricsData, MetricsResponse } from "../types/types";
 
 async function fetchMetrics(): Promise<MetricsData> {
-  const response = await fetch(METRICS_API_URL ?? "");
+  const search = new URLSearchParams(window.location.search);
+  const metricsUrl = search.get("metricsUrl");
+  
+  const response = await fetch(metricsUrl ?? METRICS_API_URL ?? "");
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
   const data: MetricsResponse = await response.json();


### PR DESCRIPTION
# Pull Request

## Description
<!-- Briefly describe what this PR does and why -->
Metrics dashboard is currently using the metrics url from the env variable, but in order to intiaite the metrics-dashboard from the host we are creating a new `/metrics-dashboard` url from the host and is sending the metricsurl as searchparam to load the metrics-dashboard.

## Changes
- Getting the metrics url from search param and using it to poll for metrics conditions so if the search param is empty we will fall back to env variable which could be `http://localhost:8080/metrics`
- Adding an `.env.exmaple` file to add a sample url.

## Related Issue
<!-- Link to the issue this PR addresses, if any -->
Fixes #133 
A part of #80 

## Steps to Test
<!-- Simple steps to verify this PR works -->
1. Pull branch locally
2. Run the app or service
3. Verify core functionality works as expected (e.g., main page loads, API responds)

## Checklist
- [ ] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [ ] PR is self-contained and focused
- [ ] Code does not break any existing features
- [ ] Code passes personal internal testing

## Notes
<!-- Any additional context for reviewers -->
